### PR TITLE
Add `emcc` toolchain for WASM builds using Emscripten

### DIFF
--- a/configure
+++ b/configure
@@ -645,6 +645,8 @@ if is_host "msys"; then
     _target_plat_default="mingw"
 elif is_host "freebsd"; then
     _target_plat_default="bsd"
+elif test_nz "${EMSDK}"; then
+    _target_plat_default="wasm"
 fi
 
 # set the default target architecture

--- a/configure
+++ b/configure
@@ -409,9 +409,15 @@ path_toolname() {
         clang) toolname="clang";;
         clang-*) toolname="clang";;
         */clang-*) toolname="clang";;
+        */emcc) toolname="clang";;
+        emcc) toolname="clang";;
+        */em++) toolname="clangxx";;
+        em++) toolname="clangxx";;
         *-ar) toolname="ar";;
         */ar) toolname="ar";;
         ar) toolname="ar";;
+        */emar) toolname="ar";;
+        emar) toolname="ar";;
         cc) toolname="gcc";;
         */cc) toolname="gcc";;
         c++) toolname="gxx";;

--- a/configure
+++ b/configure
@@ -2878,6 +2878,18 @@ toolchain "aarch64_linux_gnu"
     set_toolset "ar" "aarch64-linux-gnu-ar" "ar"
 toolchain_end
 
+# emcc toolchain (wasm32)
+toolchain "emcc"
+    set_toolset "as" "emcc"
+    set_toolset "cc" "emcc"
+    set_toolset "cxx" "emcc" "em++"
+    set_toolset "mm" "emcc"
+    set_toolset "mxx" "emcc" "em++"
+    set_toolset "ld" "em++" "emcc"
+    set_toolset "sh" "em++" "emcc"
+    set_toolset "ar" "emar" "ar"
+toolchain_end
+
 # check platform
 _check_platform() {
     if test "x${_target_plat}" = "x"; then
@@ -3194,6 +3206,8 @@ _toolchain_detect() {
             else
                 toolchains="x86_64_w64_mingw32"
             fi
+        elif is_plat "wasm"; then
+            toolchains="emcc"
         elif is_plat "linux" && ! is_arch "${os_arch}"; then
             toolchains="envs"
             if is_arch "arm64"; then

--- a/configure
+++ b/configure
@@ -409,15 +409,15 @@ path_toolname() {
         clang) toolname="clang";;
         clang-*) toolname="clang";;
         */clang-*) toolname="clang";;
-        */emcc) toolname="clang";;
-        emcc) toolname="clang";;
-        */em++) toolname="clangxx";;
-        em++) toolname="clangxx";;
+        */emcc) toolname="emcc";;
+        emcc) toolname="emcc";;
+        */em++) toolname="emxx";;
+        em++) toolname="emxx";;
         *-ar) toolname="ar";;
         */ar) toolname="ar";;
         ar) toolname="ar";;
-        */emar) toolname="ar";;
-        emar) toolname="ar";;
+        */emar) toolname="emar";;
+        emar) toolname="emar";;
         cc) toolname="gcc";;
         */cc) toolname="gcc";;
         c++) toolname="gxx";;
@@ -946,6 +946,8 @@ _get_abstract_flags() {
             gxx) _get_abstract_flag_for_gcc_clang "${toolkind}" "${toolname}" "${itemname}" "${value}"; flag="${_ret}";;
             clang) _get_abstract_flag_for_gcc_clang "${toolkind}" "${toolname}" "${itemname}" "${value}"; flag="${_ret}";;
             clangxx) _get_abstract_flag_for_gcc_clang "${toolkind}" "${toolname}" "${itemname}" "${value}"; flag="${_ret}";;
+            emcc) _get_abstract_flag_for_gcc_clang "${toolkind}" "${toolname}" "${itemname}" "${value}"; flag="${_ret}";;
+            emxx) _get_abstract_flag_for_gcc_clang "${toolkind}" "${toolname}" "${itemname}" "${value}"; flag="${_ret}";;
             *) raise "unknown toolname(${toolname})!" ;;
         esac
         if test_nz "${flag}"; then
@@ -1595,7 +1597,10 @@ _get_target_toolchain_flags() {
         gxx) _get_target_toolchain_flags_for_gcc "${name}" "${toolkind}"; flags="${_ret}";;
         clang) _get_target_toolchain_flags_for_clang "${name}" "${toolkind}"; flags="${_ret}";;
         clangxx) _get_target_toolchain_flags_for_clang "${name}" "${toolkind}"; flags="${_ret}";;
+        emcc) _get_target_toolchain_flags_for_clang "${name}" "${toolkind}"; flags="${_ret}";;
+        emxx) _get_target_toolchain_flags_for_clang "${name}" "${toolkind}"; flags="${_ret}";;
         ar) _get_target_toolchain_flags_for_ar "${name}" "${toolkind}"; flags="${_ret}";;
+        emar) _get_target_toolchain_flags_for_ar "${name}" "${toolkind}"; flags="${_ret}";;
         *) raise "unknown toolname(${toolname})!" ;;
     esac
     _ret="${flags}"
@@ -2951,6 +2956,8 @@ _toolchain_compcmd() {
         gxx) _toolchain_compcmd_for_gcc_clang "${program}" "${objectfile}" "${sourcefile}" "${flags}"; compcmd="${_ret}";;
         clang) _toolchain_compcmd_for_gcc_clang "${program}" "${objectfile}" "${sourcefile}" "${flags}"; compcmd="${_ret}";;
         clangxx) _toolchain_compcmd_for_gcc_clang "${program}" "${objectfile}" "${sourcefile}" "${flags}"; compcmd="${_ret}";;
+        emcc) _toolchain_compcmd_for_gcc_clang "${program}" "${objectfile}" "${sourcefile}" "${flags}"; compcmd="${_ret}";;
+        emxx) _toolchain_compcmd_for_gcc_clang "${program}" "${objectfile}" "${sourcefile}" "${flags}"; compcmd="${_ret}";;
         *) raise "unknown toolname(${toolname})!" ;;
     esac
     _ret="${compcmd}"
@@ -2969,7 +2976,10 @@ _toolchain_linkcmd() {
         gxx) _toolchain_linkcmd_for_gcc_clang "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
         clang) _toolchain_linkcmd_for_gcc_clang "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
         clangxx) _toolchain_linkcmd_for_gcc_clang "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
+        emcc) _toolchain_linkcmd_for_gcc_clang "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
+        emxx) _toolchain_linkcmd_for_gcc_clang "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
         ar) _toolchain_linkcmd_for_ar "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
+        emar) _toolchain_linkcmd_for_ar "${toolkind}" "${program}" "${binaryfile}" "${objectfiles}" "${flags}"; linkcmd="${_ret}";;
         *) raise "unknown toolname(${toolname})!" ;;
     esac
     _ret="${linkcmd}"
@@ -3104,7 +3114,10 @@ _toolchain_try_program() {
         gxx) _toolchain_try_gxx "${kind}" "${program}" && ok=true;;
         clang) _toolchain_try_clang "${kind}" "${program}" && ok=true;;
         clangxx) _toolchain_try_clangxx "${kind}" "${program}" && ok=true;;
+        emcc) _toolchain_try_clang "${kind}" "${program}" && ok=true;;
+        emxx) _toolchain_try_clangxx "${kind}" "${program}" && ok=true;;
         ar) _toolchain_try_ar "${kind}" "${program}" && ok=true;;
+        emar) _toolchain_try_ar "${kind}" "${program}" && ok=true;;
         *) raise "unknown toolname(${toolname})!" ;;
     esac
     if ${ok}; then
@@ -3835,6 +3848,8 @@ _gmake_add_build_object() {
         gxx) _gmake_add_build_object_for_gcc_clang "${sourcekind}" "${sourcefile}" "${objectfile}" "${flagname}";;
         clang) _gmake_add_build_object_for_gcc_clang "${sourcekind}" "${sourcefile}" "${objectfile}" "${flagname}";;
         clangxx) _gmake_add_build_object_for_gcc_clang "${sourcekind}" "${sourcefile}" "${objectfile}" "${flagname}";;
+        emcc) _gmake_add_build_object_for_gcc_clang "${sourcekind}" "${sourcefile}" "${objectfile}" "${flagname}";;
+        emxx) _gmake_add_build_object_for_gcc_clang "${sourcekind}" "${sourcefile}" "${objectfile}" "${flagname}";;
         *) raise "unknown toolname(${toolname})!" ;;
     esac
     echo "" >> "${xmake_sh_makefile}"
@@ -3913,7 +3928,10 @@ _gmake_add_build_target() {
         gxx) _gmake_add_build_target_for_gcc_clang "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
         clang) _gmake_add_build_target_for_gcc_clang "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
         clangxx) _gmake_add_build_target_for_gcc_clang "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
+        emcc) _gmake_add_build_target_for_gcc_clang "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
+        emxx) _gmake_add_build_target_for_gcc_clang "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
         ar) _gmake_add_build_target_for_ar "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
+        emar) _gmake_add_build_target_for_ar "${toolkind}" "${targetfile}" "${objectfiles}" "${flagname}";;
         *) raise "unknown toolname(${toolname})!" ;;
     esac
     echo "" >> "${xmake_sh_makefile}"


### PR DESCRIPTION
First of all, thanks so much for creating this project, it fits my requirements perfectly!  I wanted a better way to build widely cross-platform apps without relying on CMake, etc, and I happened to find XMake and xmake.sh a few weeks ago.  Great work!

This PR updates `path_toolname` to detect the names of the Emscripten tools so that `configure` can be used with the `emconfigure` command.  After these changes (and installing the Emscripten SDK), one can build their project for the web by using the following commands:

```
emconfigure ./configure
make
```

I'm not sure if a full toolchain description should be added for Emscripten instead, but these minimal changes seemed to be enough to get everything working perfectly on my end.